### PR TITLE
DRAFT #7801

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,50 @@
+
+{
+  // Automatically created by phoityne-vscode extension.
+
+  "version": "2.0.0",
+  "presentation": {
+    "reveal": "always",
+    "panel": "new"
+  },
+  "tasks": [
+    {
+      // F7
+      "group": {
+        "kind": "build",
+        "isDefault": true
+      },
+      "label": "haskell build",
+      "type": "shell",
+      //"command": "cabal configure && cabal build"
+      "command": "stack build"
+    },
+    {
+      // F6
+      "group": "build",
+      "type": "shell",
+      "label": "haskell clean & build",
+      //"command": "cabal clean && cabal configure && cabal build"
+      "command": "stack clean && stack build"
+      //"command": "stack clean ; stack build"  // for powershell
+    },
+    {
+      // F8
+      "group": {
+        "kind": "test",
+        "isDefault": true
+      },
+      "type": "shell",
+      "label": "haskell test",
+      //"command": "cabal test"
+      "command": "stack test"
+    },
+    {
+      // F6
+      "isBackground": true,
+      "type": "shell",
+      "label": "haskell watch",
+      "command": "stack build --test --no-run-tests --file-watch"
+    }
+  ]
+}

--- a/cabal-install/src/Distribution/Client/IndexUtils.hs
+++ b/cabal-install/src/Distribution/Client/IndexUtils.hs
@@ -38,6 +38,7 @@ module Distribution.Client.IndexUtils (
   parsePackageIndex,
   updateRepoIndexCache,
   updatePackageIndexCacheFile,
+  readRepoIndex,
   writeIndexTimestamp,
   currentIndexTimestamp,
 


### PR DESCRIPTION
Notes:

Find where the update command retrieves the repo index containing the names and version numbers of all packages

-- cabal-install / src / Distribution / Client / CmdUpdate.hs L111
updateAction :: NixStyleFlags () -> [String] -> GlobalFlags -> IO ()
Takes arguments and flags to update repos


-- cabal-install / src / Distribution / Client / CmdUpdate.hs L176
updateRepo :: Verbosity -> UpdateFlags -> RepoContext -> (Repo, RepoIndexState) -> IO ()
Updates ONE repo


-- cabal-install / src / Distribution / Client / FetchUtils.hs L204
downloadIndex :: HttpTransport -> Verbosity -> RemoteRepo -> FilePath -> IO DownloadResult
Downloads the index file for that repo


-- RepoName.hs L19
newtype RepoName = RepoName { unRepoName :: String }
  deriving (Show, Eq, Ord, Generic)

Need to find where the build command extracts the index file downloaded with update

-- cabal-install / src / Distribution / Client / CmdBuild.hs L99
buildAction :: NixStyleFlags BuildFlags -> [String] -> GlobalFlags -> IO ()

-- cabal-install / src / Distribution / Client / ProjectOrchestration.hs L99
runProjectPreBuildPhase :: Verbosity
	-> ProjectBaseContext
	-> (ElaboratedInstallPlan -> IO (ElaboratedInstallPlan, TargetsMap))
	-> IO ProjectBuildContext

-- cabal-install / src / Distribution / Client / ProjectPlanning.hs L396
rebuildInstallPlan :: Verbosity
	-> DistDirLayout -> CabalDirLayout
	-> ProjectConfig
	-> [PackageSpecifier UnresolvedSourcePackage]
	-> IO ( ElaboratedInstallPlan  -- with store packages
		, ElaboratedInstallPlan  -- with source packages
		, ElaboratedSharedConfig
		, IndexUtils.TotalIndexState
		, IndexUtils.ActiveRepos
	)

-- MISC data
readRepoIndex :: Verbosity -> RepoContext -> Repo -> RepoIndexState
	-> IO (PackageIndex UnresolvedSourcePackage, [Dependency], IndexStateInfo)


readPackageIndexCacheFile :: Package pkg => Verbosity
	-> (PackageEntry -> pkg)
	-> Index
	-> RepoIndexState
	-> IO (PackageIndex pkg, [Dependency], IndexStateInfo)
	
data Dependency = Dependency
	PackageName
	VersionRange
	(NonEmptySet LibraryName)
	-- ^ The set of libraries required from the package.
	-- Only the selected libraries will be built.
	-- It does not affect the cabal-install solver yet.
	deriving (Generic, Read, Show, Eq, Typeable, Data)

data VersionRange
	= ThisVersion            Version -- = version
	| LaterVersion           Version -- > version  (NB. not >=)
	| OrLaterVersion         Version -- >= version
	| EarlierVersion         Version -- < version
	| OrEarlierVersion       Version -- <= version
	| MajorBoundVersion      Version -- @^>= ver@ (same as >= ver && < MAJ(ver)+1)
	| UnionVersionRanges     VersionRange VersionRange
	| IntersectVersionRanges VersionRange VersionRange
	deriving ( Data, Eq, Generic, Read, Show, Typeable )

data Version = PV0 {-# UNPACK #-} !Word64
	 | PV1 !Int [Int]
	 -- NOTE: If a version fits into the packed Word64
	 -- representation (i.e. at most four version components
	 -- which all fall into the [0..0xfffe] range), then PV0
	 -- MUST be used. This is essential for the 'Eq' instance
	 -- to work.
	   deriving (Data,Eq,Generic,Typeable)
	
-- Test Cases
No repos are given
One repo is given
More than one repo is given

No default repos are specified
One default repo is configured
More than one default repo is configured

Local repos
Remote repos
